### PR TITLE
Make net-ldap dependency required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'ruby-ldapserver', '~> 0.5.0'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,23 @@
+PATH
+  remote: .
+  specs:
+    fakeldap (0.1)
+      net-ldap (~> 0)
+      ruby-ldapserver (~> 0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    ruby-ldapserver (0.5.1)
+    net-ldap (0.13.0)
+    rspec (0.9.4)
+    ruby-ldapserver (0.5.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  ruby-ldapserver (~> 0.5.0)
+  fakeldap!
+  rspec (~> 0)
+
+BUNDLED WITH
+   1.11.2

--- a/fakeldap.gemspec
+++ b/fakeldap.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |s|
   s.summary     = "A fake LDAP server for use in testing"
   s.description = "Supports: Admin user bind operation, Regular user authentication, Create (add), read (search), update (modify), and delete operations for users and groups"
 
+  s.add_dependency 'net-ldap', '~> 0'
+  s.add_dependency 'ruby-ldapserver', '~> 0.5.0'
   s.add_development_dependency 'rspec', '~> 0'
-  s.add_development_dependency 'net-ldap', '~> 0'
 
   s.files        = Dir.glob("{lib,vendor}/**/*") + %w(LICENSE README.md)
   s.require_path = 'lib'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rspec'
 require 'net/ldap'
 
 $:.unshift(File.expand_path('../../lib', __FILE__))


### PR DESCRIPTION
Hi!
I tried to add `fakeldap` into my test suite, but when I run `rspec` command it fails with `failed to load` error. This PR fixes this.
